### PR TITLE
セグ木のupdate周りを変更

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -43,7 +43,7 @@
 "test/structure/lazy_segment_tree.test.cpp": "2020-05-06 01:41:24 +0900",
 "test/structure/persistent_segment_tree.test.cpp": "2020-05-06 01:41:24 +0900",
 "test/structure/segment_rbst.test.cpp": "2020-05-06 01:41:24 +0900",
-"test/structure/segment_tree.test.cpp": "2020-05-06 01:41:24 +0900",
+"test/structure/segment_tree.test.cpp": "2020-06-17 20:23:04 +0900",
 "test/structure/union_find.test.cpp": "2020-05-06 01:41:24 +0900",
 "test/structure/weighted_union_find.test.cpp": "2020-05-06 01:41:24 +0900"
 }

--- a/test/structure/segment_tree.test.cpp
+++ b/test/structure/segment_tree.test.cpp
@@ -6,11 +6,12 @@ int main() {
     int N, Q;
     cin >> N >> Q;
     SegmentTree<int> seg(N, [](int a,int b){return min(a,b);},
+            [](int a, int b){return b;},
             (1ll<<31)-1);
     while (Q--) {
         int T, X, Y;
         cin >> T >> X >> Y;
-        if (T == 0) seg.update(X, [&](int a){return Y;});
+        if(T == 0) seg.update(X, Y);
         else printf("%d\n", seg.query(X, Y + 1));
     }
 }


### PR DESCRIPTION
・updateにつかう演算を毎回指定する仕様になってたので、初期化時に指定するように変更した
・同じセグ木のインスタンスに対して一点加算と一点更新の両方をやりたい場合は、一点更新で初期化しておいて、加算はupdate(idx, val + segtree[idx])みたいにするとよい